### PR TITLE
[WIP] updates to dag size and seedhash from Energi main net

### DIFF
--- a/include/egihash.h
+++ b/include/egihash.h
@@ -23,7 +23,7 @@ namespace egihash
 	{
 		/** \brief DAG_MAGIC_BYTES is the starting sequence of a DAG file, used for identification.
 		*/
-		static constexpr char DAG_MAGIC_BYTES[] = "EGIHASH_DAG";
+		static constexpr char DAG_MAGIC_BYTES[] = "NRGHASH_DAG";
 
 		/** \brief DAG_FILE_HEADER_SIZE is the expected size of a DAG file header.
 		*/
@@ -31,7 +31,7 @@ namespace egihash
 
 		/** \brief DAG_FILE_MINIMUM_SIZE is the size of the DAG file at epoch 0.
 		*/
-		static constexpr uint64_t DAG_FILE_MINIMUM_SIZE = 1090516864;
+		static constexpr uint64_t DAG_FILE_MINIMUM_SIZE = 2641099136;
 
 		/** \brief CALLBACK_FREQUENCY determines how often callbacks will be called.
 		*
@@ -55,21 +55,21 @@ namespace egihash
 		*/
 		static constexpr uint32_t WORD_BYTES = 4u;
 
-		/** \brief The number of bytes in the dataset at genesis.
-		*/
-		static constexpr uint32_t DATASET_BYTES_INIT = 1u << 30u;
-
 		/** \brief The growth of the dataset in bytes per epoch.
 		*/
 		static constexpr uint32_t DATASET_BYTES_GROWTH = 1u << 23u;
 
-		/** \brief The number of bytes in the cache at genesis.
+		/** \brief The number of bytes in the dataset at genesis.
 		*/
-		static constexpr uint32_t CACHE_BYTES_INIT = 1u << 24u;
+		static constexpr uint32_t DATASET_BYTES_INIT = (1u << 30u) + (DATASET_BYTES_GROWTH * 182);
 
 		/** \brief The growth of the cache in bytes per epoch.
 		*/
 		static constexpr uint32_t CACHE_BYTES_GROWTH = 1u << 17u;
+
+		/** \brief The number of bytes in the cache at genesis.
+		*/
+		static constexpr uint32_t CACHE_BYTES_INIT = (1u << 24u) + (CACHE_BYTES_GROWTH * 182);
 
 		/** \brief Ratio of the size of the DAG in bytes relative to the size of the cache in bytes..
 		*/
@@ -77,9 +77,9 @@ namespace egihash
 
 		/** \brief The number of blocks which constitute one epoch.
 		*
-		*	The DAG and cache must be regenerated once per epoch.
+		*	The DAG and cache must be regenerated once per epoch. (approximately 120 hours)
 		*/
-		static constexpr uint32_t EPOCH_LENGTH = 30000u;
+		static constexpr uint32_t EPOCH_LENGTH = 7200u;
 
 		/** \brief The width of the mix hash for egihash.
 		*/
@@ -151,11 +151,13 @@ namespace egihash
 	};
 
 	/** \brief epoch0_seedhash is is the seed hash for the genesis block and first epoch of the DAG.
-	*			All seed hashes for subsequent epochs will be generated from this seedhash.
+	*		All seed hashes for subsequent epochs will be generated from this seedhash.
+	*		This hash was chosen as: seed = SHA256(SHA256(Concatenate(EthereumBlock5439314Hash, DashBlock853406Hash)))
+	* 		Using two block hashes from other blockchains serves as a proof of the timestamp in the genesis block.
 	*
 	*	This represents a keccak-256 hash that will be used as input for building the DAG/cache.
 	*/
-	static constexpr char epoch0_seedhash[] = "\xa8\x49\x4b\xb2\x89\x5b\xd7\xed\x18\xbb\x39\xb7\xb2\x8a\xf5\x1d\xec\x51\xf7\xca\xd3\x30\xc1\x68\xf1\xbd\x1c\x90\xe7\x61\x4c\x32";
+	static constexpr char epoch0_seedhash[] = "\xe8\xbc\xb1\xcf\x8a\x60\x16\x25\x11\x7e\x59\xb5\xf2\xdc\x8c\x36\x6e\x14\x04\x83\x0a\xe9\xd2\x5f\x65\x2b\xe6\x7a\xc9\xbb\x81\x5b";
 	static constexpr uint8_t size_epoch0_seedhash = sizeof(epoch0_seedhash) - 1;
 	static_assert(size_epoch0_seedhash == 32, "Invalid seedhash");
 


### PR DESCRIPTION
* Fixes #36 
* updates seedhash to energi mainnet
* increased epoch 0 dag size to equivalent of ethereum epoch 182
* decreased epoch length in blocks for 120 hour epoch time

WIP until unit tests are updated